### PR TITLE
FEAT: test select team view

### DIFF
--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -81,7 +81,7 @@ class SelectTeamViewTest(TestCaseUtils):
             reverse("battle-team-pokemons", kwargs={"pk": self.team.id})
         )
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/login/"))
+        self.assertTrue(response.url.startswith(reverse("login")))
 
     def test_logged_in_uses_correct_template(self):
         response = self.auth_client.get(

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -112,6 +112,9 @@ class SelectTeamViewTest(TestCaseUtils):
             team_pokemon_data,
             follow=True,
         )
+        team_pokemon = TeamPokemon.objects.filter(team=self.team)
+        self.assertTrue(team_pokemon)
+
         self.assertRedirects(response, "/battle/")
 
     def test_creator_select_invalid_pokemon(self):

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 
 from model_bakery import baker
 
-from battles.models import Battle
+from battles.models import Battle, TeamPokemon
 from common.utils.tests import TestCaseUtils
 
 
@@ -113,3 +113,27 @@ class SelectTeamViewTest(TestCaseUtils):
             follow=True,
         )
         self.assertRedirects(response, "/battle/")
+
+    def test_creator_select_invalid_pokemon(self):
+        team_pokemon_data = {
+            "pokemon_1": "momo",
+            "position_1": 1,
+            "pokemon_2": "eevee",
+            "position_2": 1,
+            "pokemon_3": "nidorina",
+            "position_3": 1,
+        }
+        self.auth_client.post(
+            reverse(
+                "battle-team-pokemons",
+                kwargs={
+                    "pk": self.team.id,
+                },
+            ),
+            team_pokemon_data,
+            follow=True,
+        )
+
+        team_pokemon = TeamPokemon.objects.filter(team=self.team)
+        self.assertFalse(team_pokemon)
+        self.assertRaisesMessage(ValueError, "ERROR: It's not a valid pokemon.")

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -80,8 +80,6 @@ class SelectTeamViewTest(TestCaseUtils):
         response = self.auth_client.get(
             reverse("battle-team-pokemons", kwargs={"pk": self.team.id})
         )
-        # self.assertRedirects(response, "/login/?next=/battle/<int:pk>/team/new/")
-        # Can't use assertRedirect, because the redirect URL is unpredictable
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.url.startswith("/login/"))
 

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -141,7 +141,6 @@ class SelectTeamViewTest(TestCaseUtils):
 
     def test_missing_pokemon(self):
         team_pokemon_data = {
-            "pokemon_1": "",
             "position_1": 1,
             "pokemon_2": "eevee",
             "position_2": 2,

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -113,6 +113,10 @@ class SelectTeamViewTest(TestCaseUtils):
         team_pokemon = TeamPokemon.objects.filter(team=self.team)
         self.assertTrue(team_pokemon)
 
+        self.assertEqual(team_pokemon_data["pokemon_1"], team_pokemon[0].pokemon.name)
+        self.assertEqual(team_pokemon_data["pokemon_2"], team_pokemon[1].pokemon.name)
+        self.assertEqual(team_pokemon_data["pokemon_3"], team_pokemon[2].pokemon.name)
+
         self.assertRedirects(response, "/battle/")
 
     def test_creator_select_invalid_pokemon(self):

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -119,9 +119,9 @@ class SelectTeamViewTest(TestCaseUtils):
             "pokemon_1": "momo",
             "position_1": 1,
             "pokemon_2": "eevee",
-            "position_2": 1,
+            "position_2": 2,
             "pokemon_3": "nidorina",
-            "position_3": 1,
+            "position_3": 3,
         }
         self.auth_client.post(
             reverse(

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -138,3 +138,27 @@ class SelectTeamViewTest(TestCaseUtils):
         team_pokemon = TeamPokemon.objects.filter(team=self.team)
         self.assertFalse(team_pokemon)
         self.assertRaisesMessage(ValueError, "ERROR: It's not a valid pokemon.")
+
+    def test_missing_pokemon(self):
+        team_pokemon_data = {
+            "pokemon_1": "",
+            "position_1": 1,
+            "pokemon_2": "eevee",
+            "position_2": 2,
+            "pokemon_3": "nidorina",
+            "position_3": 3,
+        }
+        self.auth_client.post(
+            reverse(
+                "battle-team-pokemons",
+                kwargs={
+                    "pk": self.team.id,
+                },
+            ),
+            team_pokemon_data,
+            follow=True,
+        )
+
+        team_pokemon = TeamPokemon.objects.filter(team=self.team)
+        self.assertFalse(team_pokemon)
+        self.assertRaisesMessage(ValueError, "ERROR: All fields are required.")

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -34,7 +34,7 @@ class CreateBattleView(LoginRequiredMixin, CreateView):
         return HttpResponseRedirect(reverse_lazy("battle-team-pokemons", args=(creator_team_id,)))
 
 
-class SelectTeamView(UpdateView):
+class SelectTeamView(LoginRequiredMixin, UpdateView):
     model = Team
     template_name = "battles/battle-team-pokemons.html"
     form_class = TeamForm
@@ -85,7 +85,7 @@ class BattleListView(LoginRequiredMixin, ListView):
         return context
 
 
-class BattleDetailView(DetailView):
+class BattleDetailView(LoginRequiredMixin, DetailView):
     model = Battle
     template_name = "battles/battle_detail.html"
     context_object_name = "battle"


### PR DESCRIPTION
## Objective and Motivation
-  The view that select pokemons

## Test Cases
| Test     | Description  | Assert     |
| :---        |    :----   |          :--- |
| <code>test_redirect_if_not_logged_in </code>  |   If isn't logged in, they are redirected to login  |   <ul><li> <code> assertEqual</code> - Check if got a response "redirect" </li><li> Can't use assertRedirect, because the redirect URL is unpredictable </li><li> <code>assertTrue</code> - if they were redirected to login </li></ul>   |
| <code>test_logged_in_uses_correct_template </code>   | Happy Path    |  <ul><li> <code> assertEqual</code> -  Check if user is logged in </li><li> <code>assertEqual</code> - Check if got a response "success" </li><li> <code>assertTemplateUsed</code> - Check used correct template</li></ul>   |
| <code>test_creator_select_valid_team </code>   |    Happy Path   |   <ul><li> <code> assertTrue</code> - if the team pokemon was created  </li><li> <code>assertEqual</code>  -  Check if got a response "redirect" </li></ul>|
| <code>test_creator_select_invalid_pokemon </code>   | It is not the valid name of pokemon.  |  <ul><li><code> assertFalse</code> - if the team pokemon wasn't created  </li><li> <code>assertRaisesMessage</code></li></ul>  |
| <code>test_missing_pokemon </code>   | It is missing a pokemon.  |  <ul><li><code> assertFalse</code> - if the team pokemon wasn't created  </li><li> <code>assertRaisesMessage</code></li></ul>  |

* I didn't do any more tests with invalid entries, as they've all been tested in [FEAT: test TeamForm #41
](https://github.com/naftalima/pokebattle/pull/41).
