### PR TITLE
FEAT: Permissions

### DIFF
--- a/backend/battles/api/permissions.py
+++ b/backend/battles/api/permissions.py
@@ -11,6 +11,6 @@ class IsTrainerOfTeam(permissions.BasePermission):
         return False
 
     def has_object_permission(self, request, view, obj):
-        if str(obj.trainer) == str(request.user):
+        if str(obj.trainer.email) == str(request.user.email):
             return True
         return False

--- a/backend/battles/api/permissions.py
+++ b/backend/battles/api/permissions.py
@@ -1,7 +1,7 @@
 from rest_framework import permissions
 
 
-class IsTheTrainerOfTheTeam(permissions.BasePermission):
+class IsTrainerOfTeam(permissions.BasePermission):
 
     message = "This user isn't the trainer of this team."
 

--- a/backend/battles/api/tests/test_views.py
+++ b/backend/battles/api/tests/test_views.py
@@ -162,6 +162,7 @@ class SelectTeamTest(TestCaseUtils):
             return fake_json
 
         mock_get_pokemon.side_effect = side_effect_func
+        mock_get_pokemon.assert_not_called()
 
         team_pokemon_data = {
             "pokemon_1": "pikachu",
@@ -236,6 +237,8 @@ class SelectTeamTest(TestCaseUtils):
         )
 
         self.assertResponse403(response)
+
+        mock_get_pokemon.assert_not_called()
 
         team_pokemon = TeamPokemon.objects.filter(team=self.team_creator)
         self.assertFalse(team_pokemon)

--- a/backend/battles/api/tests/test_views.py
+++ b/backend/battles/api/tests/test_views.py
@@ -206,9 +206,11 @@ class SelectTeamTests(TestCaseUtils):
             "position_3": 3,
         }
 
-        self.auth_client.patch(
+        response = self.auth_client.patch(
             view_url, json.dumps(team_pokemon_data), content_type="application/json"
         )
+
+        self.assertResponse403(response)
 
         team_pokemon = TeamPokemon.objects.filter(team=self.team_creator)
         self.assertFalse(team_pokemon)

--- a/backend/battles/api/views.py
+++ b/backend/battles/api/views.py
@@ -2,7 +2,7 @@ from django.db.models import Q
 
 from rest_framework import generics, permissions
 
-from battles.api.permissions import IsTheTrainerOfTheTeam
+from battles.api.permissions import IsTrainerOfTeam
 from battles.api.serializers import BattleSerializer, CreateBattleSerializer, SelectTeamSerializer
 from battles.models import Battle, Team
 
@@ -26,4 +26,4 @@ class CreateBattleView(generics.CreateAPIView):
 class SelectTeamView(generics.UpdateAPIView):
     serializer_class = SelectTeamSerializer
     queryset = Team.objects.all()
-    permission_classes = [IsTheTrainerOfTheTeam]
+    permission_classes = [IsTrainerOfTeam]


### PR DESCRIPTION
## Objective and Motivation
- Only authenticated users can access endpoints
- A custom permission class `IsTheTrainerOfTheTeam` for only the trainer of the team can select pokemons for that team.